### PR TITLE
Enforce unique order app data

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,5 @@ jobs:
       uses: foundry-rs/foundry-toolchain@v1
 
     - name: Run tests
-      run: forge test -vv --fork-url "https://mainnet.infura.io/v3/e74132f416d346308763252779d7df22" --etherscan-api-key "MW5CQA6QK5YMJXP2WP3RA36HM5A7RA1IHA" --ffi
+      run: forge test -vv --threads 1 --fork-url "https://mainnet.infura.io/v3/e74132f416d346308763252779d7df22" --etherscan-api-key "MW5CQA6QK5YMJXP2WP3RA36HM5A7RA1IHA" --ffi
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ the following parameters:
 - `fromToken`: ERC20 you're swapping out of
 - `toToken`: ERC20 you're swapping into
 - `to`: the intended receiver of the bought tokens
+- `appData`: the exact app data hash used in the order
 - `priceChecker`: the address of a price checker, or `address(0)` for none; explained below
 - `priceCheckerData`: encoded data to pass to the price checker; explained below
 

--- a/src/Milkman.sol
+++ b/src/Milkman.sol
@@ -26,6 +26,7 @@ contract Milkman {
         address fromToken,
         address toToken,
         address to,
+        bytes32 appData,
         address priceChecker,
         bytes priceCheckerData
     );
@@ -43,7 +44,7 @@ contract Milkman {
     address internal immutable ROOT_MILKMAN;
 
     /// @dev Hash of the order data, hashed like so:
-    ///      kekkak256(abi.encode(orderCreator, receiver, fromToken, toToken, amountIn, priceChecker, priceCheckerData)).
+    ///      kekkak256(abi.encode(orderCreator, receiver, fromToken, toToken, amountIn, appData, priceChecker, priceCheckerData)).
     ///      In the root contract, it's set to `ROOT_MILKMAN_SWAP_HASH`.
     bytes32 public swapHash = ROOT_MILKMAN_SWAP_HASH;
 
@@ -64,6 +65,7 @@ contract Milkman {
         IERC20 fromToken,
         IERC20 toToken,
         address to,
+        bytes32 appData,
         address priceChecker,
         bytes calldata priceCheckerData
     )
@@ -77,12 +79,12 @@ contract Milkman {
         fromToken.safeTransferFrom(msg.sender, orderContract, amountIn);
 
         bytes32 _swapHash =
-            keccak256(abi.encode(msg.sender, to, fromToken, toToken, amountIn, priceChecker, priceCheckerData));
+            keccak256(abi.encode(msg.sender, to, fromToken, toToken, amountIn, appData, priceChecker, priceCheckerData));
 
         Milkman(orderContract).initialize(fromToken, _swapHash);
 
         emit SwapRequested(
-            orderContract, msg.sender, amountIn, address(fromToken), address(toToken), to, priceChecker, priceCheckerData
+            orderContract, msg.sender, amountIn, address(fromToken), address(toToken), to, appData, priceChecker, priceCheckerData
             );
     }
 
@@ -100,6 +102,7 @@ contract Milkman {
         IERC20 fromToken,
         IERC20 toToken,
         address to,
+        bytes32 appData,
         address priceChecker,
         bytes calldata priceCheckerData
     )
@@ -110,7 +113,7 @@ contract Milkman {
         require(_storedSwapHash != ROOT_MILKMAN_SWAP_HASH, "!cancel_from_root");
 
         bytes32 _calculatedSwapHash =
-            keccak256(abi.encode(msg.sender, to, fromToken, toToken, amountIn, priceChecker, priceCheckerData));
+            keccak256(abi.encode(msg.sender, to, fromToken, toToken, amountIn, appData, priceChecker, priceCheckerData));
 
         require(_storedSwapHash == _calculatedSwapHash, "!valid_creator_proof");
 
@@ -158,6 +161,7 @@ contract Milkman {
                 _order.sellToken,
                 _order.buyToken,
                 _order.sellAmount.add(_order.feeAmount),
+                _order.appData,
                 _priceChecker,
                 _priceCheckerData
             )

--- a/test/Milkman.t.sol
+++ b/test/Milkman.t.sol
@@ -65,7 +65,7 @@ contract MilkmanTest is Test {
     bytes internal constant ZERO_BYTES = bytes("0");
 
     bytes32 public constant SWAP_REQUESTED_EVENT =
-        keccak256("SwapRequested(address,address,uint256,address,address,address,address,bytes)");
+        keccak256("SwapRequested(address,address,uint256,address,address,address,bytes32,address,bytes)");
 
     address SUSHISWAP_ROUTER = 0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F;
 
@@ -396,6 +396,7 @@ contract MilkmanTest is Test {
             fromToken,
             toToken,
             address(this), // Receiver address
+            APP_DATA,
             priceChecker,
             priceCheckerData
         );
@@ -405,8 +406,8 @@ contract MilkmanTest is Test {
         address orderContract = address(0);
         for (uint8 i = 0; i < entries.length; ++i) {
             if (entries[i].topics[0] == SWAP_REQUESTED_EVENT) {
-                (orderContract,,,,,,,) =
-                    (abi.decode(entries[i].data, (address, address, uint256, address, address, address, address, bytes)));
+                (orderContract,,,,,,,,) =
+                    (abi.decode(entries[i].data, (address, address, uint256, address, address, address, bytes32, address, bytes)));
             }
         }
         assertNotEq(orderContract, address(0));
@@ -415,7 +416,7 @@ contract MilkmanTest is Test {
 
         {
             bytes32 expectedSwapHash =
-                keccak256(abi.encode(whale, address(this), fromToken, toToken, amountIn, priceChecker, priceCheckerData));
+                keccak256(abi.encode(whale, address(this), fromToken, toToken, amountIn, APP_DATA, priceChecker, priceCheckerData));
             assertEq(Milkman(orderContract).swapHash(), expectedSwapHash);
         }
 


### PR DESCRIPTION
CoW Protocol uses [app data](https://docs.cow.fi/cow-protocol/reference/core/intents/app-data) for features that are defined at a protocol level but not on-chain. An example of such features is [hooks](https://docs.cow.fi/cow-protocol/reference/core/intents/hooks).

Right now, if an order is valid for the Milkman contract, the app data of that order can be changed with another arbitrary value and the order is still valid.
The changes in this PR cause the app data to be unique for each order and determined at order creation time.

#### Changes to the test

The test on the current main branch is failing. It's a `for` loop that runs the test on a list of token and stops when any part fails.

To make sure that no regression are introduced, we first split the combined test into multiple tests, one per token. We then see [which tests fail (3/10)](https://github.com/fedgiac/milkman/actions/runs/11214884698/job/31170897796) for each token and compare the result with the [failing tests after these changes (2/10)](https://github.com/fedgiac/milkman/actions/runs/11215044485/job/31171406386). The amount of failing tests is about the same so there should be no regression in the code covered by the test. Note however that the tests aren't deterministic so this technically isn't guaranteed.

The vast majority of changes in `Milkman.t.sol` are just indentation changes.